### PR TITLE
adding a role for package/dist upgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,8 @@ Thumbs.db
 # Ignore default main.yml from each role (ONE-levels deep)
 # roles/*/defaults/main.yml
 # Ignore default main.yml from each role (TWO-levels deep)
- roles/*/*/defaults/main.yml
-
+# roles/*/*/defaults/main.yml
+.ansible/*
 prox-inventory
 proxmox.yml
 proxmox.yml.bk

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -223,7 +223,7 @@
 
 # (pathspec) Colon-separated paths in which Ansible will search for Roles.
 ;roles_path=/home/codespace/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles
-roles_path=./ansible/roles
+roles_path=/home/codespace/ansible/roles
 
 # (string) Set the main callback used to display Ansible output. You can only have one at a time.
 # You can have many other callbacks, but just one can be in charge of stdout.

--- a/ansible/playbooks/deploy_services.yaml
+++ b/ansible/playbooks/deploy_services.yaml
@@ -1,5 +1,5 @@
 - name: Deploy Docker services
-  hosts: []
+  hosts: all
   vars:
     service_list:
       - espocrm

--- a/ansible/roles/update_machines/README.md
+++ b/ansible/roles/update_machines/README.md
@@ -5,7 +5,7 @@ This role updates packages on Ubuntu, Debian, and Alpine Linux systems and reboo
 
 - `update_commands`: OS-specific package update commands for both regular and dist-upgrade.
 
-- `dist_upgrade`: Set to `true` to perform a dist-upgrade (default: `false `).
+- `dist_upgrade`: Set to `true` to perform a dist-upgrade (default: `false`).
 
 - `reboot_required`: Set to `true` to reboot if updates were applied (default: `true`).
 

--- a/ansible/roles/update_machines/README.md
+++ b/ansible/roles/update_machines/README.md
@@ -1,0 +1,22 @@
+# Ansible Role: Update & Reboot
+This role updates packages on Ubuntu, Debian, and Alpine Linux systems and reboots if necessary.
+
+## Variables
+
+- `update_commands`: OS-specific package update commands for both regular and dist-upgrade.
+
+- `dist_upgrade`: Set to `true` to perform a dist-upgrade (default: `false `).
+
+- `reboot_required`: Set to `true` to reboot if updates were applied (default: `true`).
+
+## Usage
+Add this role to your playbook and set variables as needed:
+
+```yaml
+- hosts: all
+  become: true
+  roles:
+    - role: update_machines
+      vars:
+        dist_upgrade: true # Set to `true` for dist upgrade, `false` for standard
+```

--- a/ansible/roles/update_machines/defaults/main.yaml
+++ b/ansible/roles/update_machines/defaults/main.yaml
@@ -1,10 +1,16 @@
 # Define OS-specific package update commands
 update_machines_update_commands:
   ubuntu: "apt-get update && apt-get -y upgrade"
-  ubuntu_dist: "DEBIAN_FRONTEND=noninteractive apt-get update && apt-get -y -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" dist-upgrade"
+  ubuntu_dist: >-
+    DEBIAN_FRONTEND=noninteractive apt-get update && 
+    apt-get -y -o Dpkg::Options::="--force-confdef"
+    -o Dpkg::Options::="--force-confold" dist-upgrade
 
   debian: "apt-get update && apt-get -y upgrade"
-  debian_dist: "DEBIAN_FRONTEND=noninteractive apt-get update && apt-get -y -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" dist-upgrade"
+  debian_dist: >-
+    DEBIAN_FRONTEND=noninteractive apt-get update && 
+    apt-get -y -o Dpkg::Options::="--force-confdef"
+    -o Dpkg::Options::="--force-confold" dist-upgrade
 
   alpine: "apk update && apk upgrade --available"
   alpine_dist: "apk update && apk upgrade --available && apk fix"

--- a/ansible/roles/update_machines/defaults/main.yaml
+++ b/ansible/roles/update_machines/defaults/main.yaml
@@ -1,0 +1,16 @@
+# Define OS-specific package update commands
+update_machines_update_commands:
+  ubuntu: "apt-get update && apt-get -y upgrade"
+  ubuntu_dist: "apt-get update && apt-get -y dist-upgrade"
+
+  debian: "apt-get update && apt-get -y upgrade"
+  debian_dist: "apt-get update && apt-get -y dist-upgrade"
+
+  alpine: "apk update && apk upgrade --available"
+  alpine_dist: "apk update && apk upgrade --available"
+
+# Distribution/Package Update settings
+update_machines_dist_upgrade: false # Toggle to enable/disable dist-upgrade
+
+# Reboot settings
+update_machines_reboot_required: true # Enables reboot, if necessary

--- a/ansible/roles/update_machines/defaults/main.yaml
+++ b/ansible/roles/update_machines/defaults/main.yaml
@@ -1,13 +1,13 @@
 # Define OS-specific package update commands
 update_machines_update_commands:
   ubuntu: "apt-get update && apt-get -y upgrade"
-  ubuntu_dist: "apt-get update && apt-get -y dist-upgrade"
+  ubuntu_dist: "DEBIAN_FRONTEND=noninteractive apt-get update && apt-get -y -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" dist-upgrade"
 
   debian: "apt-get update && apt-get -y upgrade"
-  debian_dist: "apt-get update && apt-get -y dist-upgrade"
+  debian_dist: "DEBIAN_FRONTEND=noninteractive apt-get update && apt-get -y -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" dist-upgrade"
 
   alpine: "apk update && apk upgrade --available"
-  alpine_dist: "apk update && apk upgrade --available"
+  alpine_dist: "apk update && apk upgrade --available && apk fix"
 
 # Distribution/Package Update settings
 update_machines_dist_upgrade: false # Toggle to enable/disable dist-upgrade

--- a/ansible/roles/update_machines/meta/main.yaml
+++ b/ansible/roles/update_machines/meta/main.yaml
@@ -1,0 +1,17 @@
+# meta/main.yaml
+galaxy_info:
+  author: Masked-Kunsiquat
+  description: "Ansible role to update packages and reboot if necessary."
+  license: MIT
+  min_ansible_version: '2.9'
+  platforms:
+    - name: Ubuntu
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - all
+    - name: Alpine
+      versions:
+        - all
+dependencies: []

--- a/ansible/roles/update_machines/tasks/main.yaml
+++ b/ansible/roles/update_machines/tasks/main.yaml
@@ -1,7 +1,12 @@
-# tasks/main.yaml
-- name: Include OS-specific update tasks/main.yaml
+---
+- name: Update system packages
   ansible.builtin.include_tasks:
-    update_packages.yaml
+    file: update_packages.yaml
+  tags:
+    - update
+    - packages
+  register: update_result
+  ignore_errors: true
 
 - name: Reboot machine if necessary
   ansible.builtin.include_tasks:

--- a/ansible/roles/update_machines/tasks/main.yaml
+++ b/ansible/roles/update_machines/tasks/main.yaml
@@ -1,0 +1,9 @@
+# tasks/main.yaml
+- name: Include OS-specific update tasks/main.yaml
+  ansible.builtin.include_tasks:
+    update_packages.yaml
+
+- name: Reboot machine if necessary
+  ansible.builtin.include_tasks:
+    reboot.yaml
+  when: reboot_required

--- a/ansible/roles/update_machines/tasks/reboot.yaml
+++ b/ansible/roles/update_machines/tasks/reboot.yaml
@@ -1,13 +1,18 @@
 # tasks/reboot.yaml
 - name: Check if reboot is required (Ubuntu/Debian only)
-  ansible.builtin.command: "needs-restarting -r"
+  ansible.builtin.stat:
+    path: /var/run/reboot-required
   register: reboot_check
-  failed_when: rebook_check.rc not in [0, 1]
-  changed_when: reboot_check.rc == 1
   when: ansible_facts['os_family'] in ['Debian']
 
 - name: Reboot the machine
+- name: Reboot the machine
   ansible.builtin.reboot:
     msg: "System reboot due to package updates"
-    pre_reboot_delay: 10
-  when: reboot_check.changed or ansible_facts['os_family'] == 'Alpine'
+    pre_reboot_delay: 30
+    post_reboot_delay: 60
+    reboot_timeout: 600
+    test_command: uptime
+  when: >
+    (reboot_check is defined and reboot_check.changed) or
+    ansible_facts['os_family'] == 'Alpine'

--- a/ansible/roles/update_machines/tasks/reboot.yaml
+++ b/ansible/roles/update_machines/tasks/reboot.yaml
@@ -1,11 +1,22 @@
 # tasks/reboot.yaml
 - name: Check if reboot is required (Ubuntu/Debian only)
-  ansible.builtin.stat:
-    path: /var/run/reboot-required
-  register: reboot_check
-  when: ansible_facts['os_family'] in ['Debian']
-
+  block:
+    - name: Check main reboot required flag
+      ansible.builtin.stat:
+        path: /var/run/reboot-required
+      register: reboot_flag
 - name: Reboot the machine
+  ansible.builtin.reboot:
+    msg: "System reboot due to package updates"
+    pre_reboot_delay: 30
+    post_reboot_delay: 60
+    reboot_timeout: 600
+    test_command: uptime
+  when: >
+    (reboot_check is defined and reboot_check.changed) or
+    ansible_facts['os_family'] == 'Alpine'
+    ansible_facts['os_family'] == 'Alpine'
+
 - name: Reboot the machine
   ansible.builtin.reboot:
     msg: "System reboot due to package updates"

--- a/ansible/roles/update_machines/tasks/reboot.yaml
+++ b/ansible/roles/update_machines/tasks/reboot.yaml
@@ -1,0 +1,13 @@
+# tasks/reboot.yaml
+- name: Check if reboot is required (Ubuntu/Debian only)
+  ansible.builtin.command: "needs-restarting -r"
+  register: reboot_check
+  failed_when: rebook_check.rc not in [0, 1]
+  changed_when: reboot_check.rc == 1
+  when: ansible_facts['os_family'] in ['Debian']
+
+- name: Reboot the machine
+  ansible.builtin.reboot:
+    msg: "System reboot due to package updates"
+    pre_reboot_delay: 10
+  when: reboot_check.changed or ansible_facts['os_family'] == 'Alpine'

--- a/ansible/roles/update_machines/tasks/update_packages.yaml
+++ b/ansible/roles/update_machines/tasks/update_packages.yaml
@@ -5,7 +5,7 @@
 
 - name: Select update command
   ansible.builtin.set_fact:
-    update_command: "{{ update_commands[ansible_facts['os_family'] | lower ~ ('_dist' if dist_upgrade else '')] }}"
+    update_command: "{{ update_machines_update_commands[ansible_facts['os_family'] | lower ~ ('_dist' if update_machines_dist_upgrade else '')] }}"
 
 - name: Update packages on Ubuntu/Debian/Alpine
   ansible.builtin.command: "{{ update_command }}"

--- a/ansible/roles/update_machines/tasks/update_packages.yaml
+++ b/ansible/roles/update_machines/tasks/update_packages.yaml
@@ -1,0 +1,13 @@
+# tasks/update_packages.yaml
+- name: Get OS family
+  ansible.builtin.setup:
+    filter: ansible_os_family
+
+- name: Select update command
+  ansible.builtin.set_fact:
+    update_command: "{{ update_commands[ansible_facts['os_family'] | lower ~ ('_dist' if dist_upgrade else '')] }}"
+
+- name: Update packages on Ubuntu/Debian/Alpine
+  ansible.builtin.command: "{{ update_command }}"
+  register: update_result
+  changed_when: "'changed' in update_result.stdout"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new Ansible role for updating packages and managing reboots across Ubuntu, Debian, and Alpine Linux systems.
	- Added configuration options for controlling update behavior and reboot requirements.
	- Included tasks for executing OS-specific package updates and conditional reboots.

- **Documentation**
	- Added a comprehensive README.md file detailing the role's functionality and usage examples.

- **Bug Fixes**
	- Implemented checks to ensure reboots occur only when necessary after updates.

- **Configuration Changes**
	- Updated the `roles_path` in the Ansible configuration for clarity in role loading.
	- Modified the `deploy_services.yaml` playbook to target all hosts in the inventory.
	- Adjusted `.gitignore` rules to refine ignored files and directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->